### PR TITLE
Add format and cargo configs, improve new file detection

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -1,0 +1,2 @@
+[build]
+rustflags = ["-C", "target-cpu=native"]

--- a/rustfmt.toml
+++ b/rustfmt.toml
@@ -1,0 +1,3 @@
+group_imports = "StdExternalCrate"
+imports_granularity = "Module"
+    

--- a/src/db.rs
+++ b/src/db.rs
@@ -1,8 +1,9 @@
-use crate::files::Match;
-
-use anyhow::Result;
 use std::collections::HashMap;
 use std::fs;
+
+use anyhow::Result;
+
+use crate::files::Match;
 
 pub async fn write_to_file(data: &HashMap<String, Match>, filename: &str) -> Result<()> {
     let encoded = bincode::encode_to_vec(data, bincode::config::standard())?;

--- a/src/files.rs
+++ b/src/files.rs
@@ -1,21 +1,21 @@
-use crate::settings;
+use std::collections::HashSet;
+use std::fs::{self, OpenOptions};
+use std::io;
+use std::path::{Path, PathBuf};
 
 use anyhow::{Context, Result, anyhow, bail};
 use bincode::{Decode, Encode};
 use chrono::{DateTime, Utc};
 use fs2::FileExt;
 use num_enum::TryFromPrimitive;
-use peppi::{game::Game, io::slippi::read};
+use peppi::game::Game;
+use peppi::io::slippi;
 use regex::Regex;
 use serde::{Deserialize, Serialize};
-use std::{
-    collections::HashSet,
-    fs::{self, OpenOptions},
-    io,
-    path::{Path, PathBuf},
-};
 use utoipa::ToSchema;
 use walkdir::WalkDir;
+
+use crate::settings;
 
 #[derive(
     Encode,
@@ -221,7 +221,7 @@ pub fn read_replay(file_path: &str) -> Result<peppi::game::immutable::Game> {
     let file = fs::File::open(file_path)
         .with_context(|| format!("Failed to open file '{}'", file_path))?;
 
-    read(
+    slippi::read(
         &mut io::BufReader::new(file),
         Some(&peppi::io::slippi::de::Opts {
             skip_frames: false,

--- a/src/files.rs
+++ b/src/files.rs
@@ -428,30 +428,25 @@ pub fn find_replay_directory() -> Option<PathBuf> {
     Some(latest_dir)
 }
 
+fn is_slp<P: AsRef<Path>>(path: P) -> bool {
+    path.as_ref().extension().is_some_and(|ext| ext == "slp")
+}
+
 pub fn detect_new_files(games_set: &HashSet<String>, directory: &PathBuf) -> Option<String> {
-    if let Ok(entries) = fs::read_dir(directory) {
-        for entry in entries.filter_map(|e| e.ok()) {
-            let filename = entry.file_name().to_string_lossy().to_string();
-
-            let file_path = directory.join(&filename).to_str().unwrap_or("").to_string();
-
-            if !games_set.contains(&file_path)
-                && !file_path.is_empty()
-                && !is_file_locked(&file_path)
-            {
-                return Some(file_path);
-            }
-        }
-    }
-
-    None
+    fs::read_dir(directory)
+        .ok()?
+        .filter_map(|e| e.ok())
+        .filter(|e| is_slp(e.path()))
+        .map(|e| directory.join(&e.path()).to_string_lossy().to_string())
+        .filter(|path| !games_set.contains(path) && !path.is_empty() && !is_file_locked(&path))
+        .next()
 }
 
 pub fn find_slp_files(directory: &str) -> Vec<String> {
     WalkDir::new(directory)
         .into_iter()
         .filter_map(|e| e.ok())
-        .filter(|e| e.path().extension().is_some_and(|ext| ext == "slp"))
+        .filter(|e| is_slp(e.path()))
         .map(|e| e.path().to_string_lossy().to_string())
         .collect()
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -5,17 +5,15 @@ mod replays;
 mod routes;
 mod settings;
 
+use std::collections::{HashMap, HashSet};
+use std::io::{self, Write};
+use std::sync::Arc;
+
 use axum::extract::ws::Message;
 use chrono::{DateTime, NaiveDate};
-use std::{
-    collections::HashMap,
-    io::{self, Write},
-    sync::Arc,
-};
-use tokio::{
-    sync::{Mutex, mpsc::UnboundedSender},
-    time::{Duration, sleep},
-};
+use tokio::sync::Mutex;
+use tokio::sync::mpsc::UnboundedSender;
+use tokio::time::{Duration, sleep};
 
 #[derive(Debug, Clone, Default, serde::Serialize)]
 pub struct Matchup {
@@ -269,7 +267,7 @@ async fn background_task(state: Arc<Mutex<AppState>>) {
 
         let mut state_guard = state.lock().await;
         let matches = &mut state_guard.matches;
-        let seen_replays: std::collections::HashSet<String> = matches.keys().cloned().collect();
+        let seen_replays: HashSet<String> = matches.keys().cloned().collect();
 
         if let Some(new_replay_file) = files::detect_new_files(&seen_replays, &latest_directory) {
             println!("\rNew replay detected: {}", new_replay_file);

--- a/src/replays.rs
+++ b/src/replays.rs
@@ -1,12 +1,12 @@
-use crate::files;
+use std::collections::HashMap;
+use std::io::{self, Write};
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Instant;
+
 use anyhow::{Context, Result};
 use rayon::prelude::*;
-use std::{
-    collections::HashMap,
-    io::{self, Write},
-    sync::atomic::{AtomicUsize, Ordering},
-    time::Instant,
-};
+
+use crate::files;
 
 #[allow(dead_code)]
 pub fn batch_process_replays(replay_dir: &str, matches: &mut HashMap<String, files::Match>) {

--- a/src/routes.rs
+++ b/src/routes.rs
@@ -1,17 +1,15 @@
-use axum::{
-    Router,
-    extract::{
-        State, WebSocketUpgrade,
-        ws::{Message, WebSocket},
-    },
-    response::{Html, IntoResponse, Json},
-    routing::{get, post},
-};
+use std::fs;
+use std::sync::Arc;
+
+use axum::Router;
+use axum::extract::ws::{Message, WebSocket};
+use axum::extract::{State, WebSocketUpgrade};
+use axum::response::{Html, IntoResponse, Json};
+use axum::routing::{get, post};
 use chrono::NaiveDateTime;
 use futures::{SinkExt, StreamExt};
 use serde::Deserialize;
 use serde_json::json;
-use std::{fs, sync::Arc};
 use tokio::sync::{Mutex, mpsc};
 use tower_http::services::ServeDir;
 use utoipa::{OpenApi, ToSchema};


### PR DESCRIPTION
- Add rustftm.toml and run formatter over all files
- Set target cpu to native to allow compiler to use x86_64 extensions found on host cpu
- Filter out non .slp files when detecting a new replay